### PR TITLE
Implement `HtmlContent` for `&String`

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -589,6 +589,7 @@ macro_rules! impl_simple_write {
 
 impl_simple_write!(String, as_ref);
 impl_simple_write!(&str, as_ref);
+impl_simple_write!(&String, as_ref);
 impl_simple_write!(Bytes, as_ref);
 impl_simple_write!(bool, raw Display);
 impl_simple_write!(u8, raw Display);


### PR DESCRIPTION
This PR implements `HtmlContent` for `&String` to make working with strings more convenient